### PR TITLE
Remove explicit port specification in deployment workflow

### DIFF
--- a/.github/workflows/_deployment.yaml
+++ b/.github/workflows/_deployment.yaml
@@ -50,5 +50,4 @@ jobs:
         run: |
           gcloud run deploy ${{ env.CLOUD_RUN_SERVICE }} \
             --image asia-northeast2-docker.pkg.dev/${{ env.GCP_PROJECT }}/${{ env.ARTIFACT_REPOSITORY }}/${{ env.IMAGE_NAME }} \
-            --region asia-northeast2 \
-            --port 3000
+            --region asia-northeast2


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- GitHub Actionsのデプロイメントワークフローから、Cloud Runサービスのデプロイ時の明示的なポート指定(`--port 3000`)を削除しました。これにより、デフォルトポートが使用されます。



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_deployment.yaml</strong><dd><code>デプロイメントワークフローからのポート指定の削除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/_deployment.yaml

- 明示的なポート指定(`--port 3000`)を削除しました。



</details>
    

  </td>
  <td><a href="https://github.com/r253-dev/NestJSTemplate/pull/11/files#diff-59174148dd22d047024993ada80360abbc739357673c4324f0538e0ee7d1cc9c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

